### PR TITLE
add apple app site association

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+	"appclips": {
+		"apps": ["6C5B687R9E.com.epam.poc.ah.SelfCheckout"]
+	}
+}


### PR DESCRIPTION
add the .well-known/apple-app-site-association file to support Apple App Clip according to:

1. https://developer.apple.com/documentation/app_clips/creating_an_app_clip
2. https://developer.apple.com/documentation/safariservices/supporting_associated_domains